### PR TITLE
added python encoding fix

### DIFF
--- a/.config/nvim/lua/plugins/lsp-config.lua
+++ b/.config/nvim/lua/plugins/lsp-config.lua
@@ -1,0 +1,17 @@
+return {
+  "neovim/nvim-lspconfig",
+  opts = {
+    setup = {
+      pyright = function(_, opts)
+        opts.capabilities = opts.capabilities or vim.lsp.protocol.make_client_capabilities()
+        opts.capabilities.general = opts.capabilities.general or {}
+        opts.capabilities.general.positionEncodings = { "utf-8" }
+      end,
+      ruff = function(_, opts)
+        opts.capabilities = opts.capabilities or vim.lsp.protocol.make_client_capabilities()
+        opts.capabilities.general = opts.capabilities.general or {}
+        opts.capabilities.general.positionEncodings = { "utf-8" }
+      end,
+    },
+  },
+}


### PR DESCRIPTION
pyright uses utf-16 encoding and ruff uses utf-8 which causes a conflict and makes the lsp not attach properly.
this fixes that issue.